### PR TITLE
Make openmc an optional dependency #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,7 @@
 
 ## Installation
 
-`libra-toolbox` relies on Python. You can install it from the official website: [python.org](https://www.python.org/downloads/).
-
-Install OpenMC:
-
-If you want to run OpenMC functions, [install OpenMC](https://docs.openmc.org/en/stable/quickinstall.html) with conda:
-
-```
-conda install -c conda-forge openmc>=0.14.0
-```
-
-
-To install `libra-toolbox`, use pip:
-
-```bash
-pip install git+https://github.com/LIBRA-project/libra-toolbox
-```
+You can find the [installation instructions](https://libra-toolbox.readthedocs.io/en/latest/installation.html#installation) in the documentation.
 
 ## Documentation
 The documentation for `libra-toolbox` is built using Sphinx and is [available online](https://libra-toolbox.readthedocs.io/en/latest/). To build the documentation locally, you can use the provided Makefile or make.bat script.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,6 +21,20 @@ To install a specific version of the code:
 
 Here, ``v0.1`` is the version number. You can replace it with the version you want to install.
 
+To install the code in editable mode (i.e. the code is installed in the current directory and any changes to the code are immediately available to the user):
+
+.. code-block:: bash
+
+   git clone https://github.com/LIBRA-project/libra-toolbox
+   cd libra-toolbox
+   pip install -e .
+
+To install the code alongside with the optional dependencies for the neutronics module, first [install OpenMC](https://docs.openmc.org/en/stable/quickinstall.html) with conda:
+
+```
+conda install -c conda-forge openmc>=0.14.0
+```
+
 To uninstall the package:
 
 .. code-block:: bash

--- a/libra_toolbox/neutronics/neutron_source.py
+++ b/libra_toolbox/neutronics/neutron_source.py
@@ -6,8 +6,17 @@ from collections.abc import Iterable
 import pandas as pd
 import numpy as np
 
+try:
+    import h5py
+    import openmc
+    from openmc import IndependentSource
+except ModuleNotFoundError:
+    pass
 
-def A325_generator_diamond(center=(0, 0, 0), reference_uvw=(0, 0, 1)) -> Iterable:
+
+def A325_generator_diamond(
+    center=(0, 0, 0), reference_uvw=(0, 0, 1)
+) -> "Iterable[IndependentSource]":
     """
     Builds the MIT-VaultLab A-325 neutron generator in OpenMC
     with data tabulated from John Ball and Shon Mackie characterization

--- a/libra_toolbox/neutronics/neutron_source.py
+++ b/libra_toolbox/neutronics/neutron_source.py
@@ -67,7 +67,7 @@ def A325_generator_diamond(center=(0, 0, 0), reference_uvw=(0, 0, 1)) -> Iterabl
         )
         strength = yields[i]
 
-        my_source = openmc.Source(
+        my_source = openmc.IndependentSource(
             space=space,
             angle=angle,
             energy=energy,

--- a/libra_toolbox/neutronics/neutron_source.py
+++ b/libra_toolbox/neutronics/neutron_source.py
@@ -5,11 +5,9 @@ from pathlib import Path
 from collections.abc import Iterable
 import pandas as pd
 import numpy as np
-import h5py
-import openmc
 
 
-def A325_generator_diamond(center=(0, 0, 0), reference_uvw=(0, 0, 1)) -> Iterable[openmc.IndependentSource]:
+def A325_generator_diamond(center=(0, 0, 0), reference_uvw=(0, 0, 1)) -> Iterable:
     """
     Builds the MIT-VaultLab A-325 neutron generator in OpenMC
     with data tabulated from John Ball and Shon Mackie characterization
@@ -28,15 +26,20 @@ def A325_generator_diamond(center=(0, 0, 0), reference_uvw=(0, 0, 1)) -> Iterabl
 
     Returns
     -------
-        list of openmc neutron sources with angular and energy distribution 
+        list of openmc neutron sources with angular and energy distribution
         and total strength of 1
     """
+    try:
+        import h5py
+        import openmc
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("openmc and h5py are required")
 
     filename = "A325_generator_diamond.h5"
     filename = str(Path(__file__).parent) / Path(filename)
 
     with h5py.File(filename, "r") as source:
-        df = pd.DataFrame(source["values/table"][()]).drop(columns='index')
+        df = pd.DataFrame(source["values/table"][()]).drop(columns="index")
         # energy values
         energies = np.array(df["Energy (MeV)"]) * 1e6
         # angle column names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,10 @@ description = "Design and analysis tools for LIBRA project"
 license = {file = "LICENSE"}
 requires-python = ">=3.6"
 dynamic = ["version"]
-dependencies = ["numpy", "pint", "scipy", "matplotlib", "sympy", "pandas", "openmc>=0.14.0", "h5py"]
+dependencies = ["numpy", "pint", "scipy", "matplotlib", "sympy", "pandas"]
 
 [project.optional-dependencies]
+extra-feature = ["openmc>=0.14.0", "h5py"]
 tests = ["pytest>=5.4.3", "pytest-cov", "nbconvert", "ipykernel"]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 dependencies = ["numpy", "pint", "scipy", "matplotlib", "sympy", "pandas"]
 
 [project.optional-dependencies]
-extra-feature = ["openmc>=0.14.0", "h5py"]
+neutronics = ["openmc>=0.14.0", "h5py"]
 tests = ["pytest>=5.4.3", "pytest-cov", "nbconvert", "ipykernel"]
 
 [tool.setuptools_scm]

--- a/test/neutronics/test_neutron_source.py
+++ b/test/neutronics/test_neutron_source.py
@@ -1,7 +1,14 @@
-from libra_toolbox.neutronics.neutron_source import *
 from collections.abc import Iterable
+from libra_toolbox.neutronics.neutron_source import A325_generator_diamond
+
+import pytest
+
 
 def test_get_avg_neutron_rate():
+    try:
+        import openmc
+    except ImportError:
+        pytest.skip("OpenMC is not installed")
 
     source = A325_generator_diamond((0, 0, 0), (0, 0, 1))
 


### PR DESCRIPTION
This PR makes `openmc` an optional dependency, allowing users to install it only if required for neutronics-related functions. Users who do not utilize these functionalities can now avoid installing `openmc`, simplifying the installation process for those using only `pip`.