### PR TITLE
import whole calibration module

### DIFF
--- a/libra_toolbox/neutron_detection/activation_foils/compass.py
+++ b/libra_toolbox/neutron_detection/activation_foils/compass.py
@@ -1,0 +1,26 @@
+
+
+def get_channel(filename):
+    """
+    Extract the channel number from a given filename string.
+
+    Parameters
+    ----------
+    filename : str
+        The input filename string containing the channel information.
+        Should look something like : "Data_CH<channel_number>@V...CSV"
+
+    Returns
+    -------
+    int
+        The extracted channel number.
+
+    Example
+    -------
+    >>> get_channel("Data_CH4@V1725_292_Background_250322.CSV")
+    4
+    """
+    return int(filename.split('@')[0][7:])
+
+
+

--- a/test/neutron_detection/test_calibration.py
+++ b/test/neutron_detection/test_calibration.py
@@ -1,7 +1,9 @@
-from libra_toolbox.neutron_detection.activation_foils.calibration import get_decay_lines
+from libra_toolbox.neutron_detection.activation_foils import calibration
 
 
-def test_get_decay_liness():
-    decay_lines = get_decay_lines(['Na22', 'Cs137'])
+def test_get_decay_lines():
+    decay_lines = calibration.get_decay_lines(['Na22', 'Cs137'])
     assert isinstance(decay_lines, dict)
     assert 'energy' in decay_lines['Na22'].keys()
+
+

--- a/test/neutron_detection/test_compass.py
+++ b/test/neutron_detection/test_compass.py
@@ -1,6 +1,12 @@
+import pytest
 from libra_toolbox.neutron_detection.activation_foils import compass
 
-def test_get_channel():
-    ch = compass.get_channel("Data_CH14@V1725_292_Background_250322.CSV")
-    assert ch==14
-
+@pytest.mark.parametrize("filename, expected_channel", [
+    ("Data_CH14@V1725_292_Background_250322.CSV", 14),
+    ("Data_CH7@V1725_123_Background_250322.CSV", 7),
+    ("Data_CH21@V1725_456_Background_250322.CSV", 21),
+])
+def test_get_channel(filename, expected_channel):
+    ch = compass.get_channel(filename)
+    assert ch == expected_channel
+   

--- a/test/neutron_detection/test_compass.py
+++ b/test/neutron_detection/test_compass.py
@@ -1,0 +1,6 @@
+from libra_toolbox.neutron_detection.activation_foils import compass
+
+def test_get_channel():
+    ch = compass.get_channel("Data_CH14@V1725_292_Background_250322.CSV")
+    assert ch==14
+


### PR DESCRIPTION
Imports the whole calibration module instead of just the function being tested as many calibration.py tests will be added in the future. 

Also adds the get_channel function for getting the detector channel from a Compass CSV filename. 