### PR TITLE
Added zirconium reactions and updated foil data and usage

### DIFF
--- a/libra_toolbox/neutron_detection/activation_foils/__init__.py
+++ b/libra_toolbox/neutron_detection/activation_foils/__init__.py
@@ -1,1 +1,1 @@
-from . import explicit, settings, calculations
+from . import explicit, settings, calculations, calibration, compass

--- a/libra_toolbox/neutron_detection/activation_foils/calibration.py
+++ b/libra_toolbox/neutron_detection/activation_foils/calibration.py
@@ -26,6 +26,7 @@ class Nuclide:
     intensity: List[float] = None
     half_life: float = None
     atomic_mass: float = None
+    abundance: float = None
 
     @property
     def decay_constant(self):
@@ -76,6 +77,20 @@ nb92m = Nuclide(
 nb93 = Nuclide(
     name="Nb93",
     atomic_mass=92.90637,
+    abundance=1.00
+)
+
+zr89 = Nuclide(
+    name="Zr89",
+    energy=[909.15],
+    intensity = [0.9904],
+    half_life=78.41 * 3600
+)
+
+zr90 = Nuclide(
+    name="Zr90",
+    atomic_mass=89.90469876,
+    abundance=0.515
 )
 
 
@@ -95,6 +110,18 @@ class Reaction:
     cross_section :
         The cross section of the reaction in cm2.
     """
+
+nb93_n2n = Reaction(
+    reactant=nb93,
+    product=nb92m,
+    cross_section=0.45966e-24 # cm2 at 14.1 MeV from IRDF-II 2020
+)
+
+zr90_n2n = Reaction(
+    reactant=zr90,
+    product=zr89,
+    cross_section=0.62389e-24 # cm2 at 14.1 MeV from IRDF-II 2020
+)
 
 
 @dataclass
@@ -151,6 +178,7 @@ class ActivationFoil:
     reaction: Reaction
     mass: float
     name: str
+    density: float
     thickness: float = None
 
     """Class to hold the information of an activation foil.
@@ -172,5 +200,4 @@ class ActivationFoil:
         Returns the number of atoms in the foil.
         """
         avogadro = 6.022e23  # part/mol
-        abundance = 1
-        return abundance * (self.mass / self.reaction.reactant.atomic_mass * avogadro)
+        return self.reaction.reactant.abundance * (self.mass / self.reaction.reactant.atomic_mass * avogadro)

--- a/libra_toolbox/neutron_detection/activation_foils/calibration.py
+++ b/libra_toolbox/neutron_detection/activation_foils/calibration.py
@@ -19,6 +19,10 @@ class Nuclide:
         The intensity of the gamma rays emitted by the nuclide.
     half_life :
         The half-life of the nuclide in seconds.
+    atomic_mass :
+        The atomic mass of the nuclide in atomic mass units (amu).
+    abundance :
+        The natural abundance of the nuclide as a fraction (default is 1.00).
     """
 
     name: str

--- a/libra_toolbox/neutron_detection/activation_foils/calibration.py
+++ b/libra_toolbox/neutron_detection/activation_foils/calibration.py
@@ -26,7 +26,7 @@ class Nuclide:
     intensity: List[float] = None
     half_life: float = None
     atomic_mass: float = None
-    abundance: float = None
+    abundance: float = 1.00
 
     @property
     def decay_constant(self):
@@ -178,7 +178,7 @@ class ActivationFoil:
     reaction: Reaction
     mass: float
     name: str
-    density: float
+    density: float = 1.0
     thickness: float = None
 
     """Class to hold the information of an activation foil.

--- a/libra_toolbox/neutron_detection/activation_foils/calibration.py
+++ b/libra_toolbox/neutron_detection/activation_foils/calibration.py
@@ -178,7 +178,7 @@ class ActivationFoil:
     reaction: Reaction
     mass: float
     name: str
-    density: float = 1.0
+    density: float = None
     thickness: float = None
 
     """Class to hold the information of an activation foil.
@@ -190,9 +190,15 @@ class ActivationFoil:
         The mass of the foil in grams.
     name :
         The name of the foil.
+    density :
+        The density of the foil in g/cm3. Default is 1.0 g/cm3.
     thickness :
         The thickness of the foil in cm.        
     """
+
+    def __post_init__(self):
+        if (self.thickness is None) != (self.density is None):
+            raise ValueError("Thickness and density must either both be floats or both be None.")
 
     @property
     def nb_atoms(self) -> float:

--- a/libra_toolbox/neutron_detection/activation_foils/compass.py
+++ b/libra_toolbox/neutron_detection/activation_foils/compass.py
@@ -671,13 +671,13 @@ def get_multipeak_area(
         # Use unimodal gaussian to estimate counts from just one peak
         peak_params = [parameters[0], parameters[1], parameters[2 + 3 * i], mean, sigma]
         all_peak_params += [peak_params]
-        gross_area = np.trapezoid(
+        gross_area = np.trapz(
             gauss(xvals[peak_start:peak_end], *peak_params),
             x=xvals[peak_start:peak_end],
         )
 
         # Cut off trapezoidal area due to compton scattering and noise
-        trap_cutoff_area = np.trapezoid(
+        trap_cutoff_area = np.trapz(
             parameters[0] + parameters[1] * xvals[peak_start:peak_end],
             x=xvals[peak_start:peak_end],
         )

--- a/test/neutron_detection/test_compass.py
+++ b/test/neutron_detection/test_compass.py
@@ -756,7 +756,7 @@ def test_get_gamma_emitted(efficiency: float):
         cross_section=20.0,
     )
 
-    foil = ActivationFoil(reaction=reaction, mass=0.1, name="TestFoil", density=1.0)
+    foil = ActivationFoil(reaction=reaction, mass=0.1, name="TestFoil")
 
     measurement = compass.SampleMeasurement("sample")
     measurement.foil = foil
@@ -825,7 +825,6 @@ def test_get_neutron_rate_very_long_half_life(photon_counts, distance):
         reaction=reaction,
         mass=0.1,
         name="TestFoil",
-        density=1.0,
         thickness=None,
     )
 
@@ -898,7 +897,6 @@ def test_get_neutron_rate_very_moderate_life(photon_counts, distance):
         reaction=reaction,
         mass=0.1,
         name="TestFoil",
-        density=1.0,
         thickness=None,
     )
 

--- a/test/neutron_detection/test_compass.py
+++ b/test/neutron_detection/test_compass.py
@@ -944,3 +944,26 @@ def test_get_neutron_rate_very_moderate_life(photon_counts, distance):
     area_of_sphere = 4 * np.pi * distance**2
     expected_neutron_rate = expected_neutron_flux * area_of_sphere
     assert np.isclose(computed_rate, expected_neutron_rate)
+
+
+def test_activationfoil_density_thickness_validation():
+
+    nuclide_reactant = Nuclide(name="TestNuclide", atomic_mass=200)
+    activated_nuclide = Nuclide(
+        name="ActivatedNuclide",
+        energy=[1000],
+        intensity=[1.0],
+        half_life=10 * 24 * 3600,  # 10 days
+    )
+
+    reaction = Reaction(
+        reactant=nuclide_reactant,
+        product=activated_nuclide,
+        cross_section=20.0,
+    )
+
+    with pytest.raises(ValueError, match="Thickness and density must either both be floats or both be None."):
+        ActivationFoil(reaction=reaction, mass=1.0, name="foil", density=1.0)
+
+    with pytest.raises(ValueError, match="Thickness and density must either both be floats or both be None."):
+        ActivationFoil(reaction=reaction, mass=1.0, name="foil", thickness=0.1)

--- a/test/neutron_detection/test_compass.py
+++ b/test/neutron_detection/test_compass.py
@@ -756,7 +756,7 @@ def test_get_gamma_emitted(efficiency: float):
         cross_section=20.0,
     )
 
-    foil = ActivationFoil(reaction=reaction, mass=0.1, name="TestFoil")
+    foil = ActivationFoil(reaction=reaction, mass=0.1, name="TestFoil", density=1.0)
 
     measurement = compass.SampleMeasurement("sample")
     measurement.foil = foil
@@ -825,6 +825,7 @@ def test_get_neutron_rate_very_long_half_life(photon_counts, distance):
         reaction=reaction,
         mass=0.1,
         name="TestFoil",
+        density=1.0,
         thickness=None,
     )
 
@@ -897,6 +898,7 @@ def test_get_neutron_rate_very_moderate_life(photon_counts, distance):
         reaction=reaction,
         mass=0.1,
         name="TestFoil",
+        density=1.0,
         thickness=None,
     )
 


### PR DESCRIPTION
I added the following:

- importing the calibration and compass modules to the initializing file 
- updated zirconium and niobium nuclide and reaction data to the calibration file for easy referencing in common use cases
- changed np.trapezoid to np.trapz to calculate the trapezoidal sum since it wasn't working with my updated version of numpy