### PR TITLE
Write compass measurements to h5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "Design and analysis tools for LIBRA project"
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dynamic = ["version"]
-dependencies = ["numpy", "pint", "scipy", "matplotlib", "sympy", "pandas", "h5py", "uproot"]
+dependencies = ["numpy", "pint", "scipy", "matplotlib", "sympy", "pandas", "h5py", "uproot", "h5py"]
 
 [project.optional-dependencies]
 neutronics = ["openmc-data-downloader"]


### PR DESCRIPTION
This PR adds two methods to `Measurement` in the compass module: `to_h5` and `from_h5`

There is the possibility to write one or several measurements to a h5 file making it more convenient.